### PR TITLE
Fix build iOS

### DIFF
--- a/build/ios/NitenTokens.swift
+++ b/build/ios/NitenTokens.swift
@@ -3,49 +3,49 @@
 // NitenTokens.swift
 //
 // Do not edit directly
-// Generated on Fri, 02 Aug 2019 17:56:31 GMT
+// Generated on Fri, 02 Aug 2019 20:57:11 GMT
 //
 
 
 import UIKit
 
 public class NitenTokens {
-    static let colorBrandFirstDark = UIColor(red: 0.13, green: 0.13, blue: 0.13, alpha:1)
-    static let colorBrandFirstExtraDark = UIColor(red: 0.00, green: 0.00, blue: 0.00, alpha:1)
-    static let colorBrandFirstLight = UIColor(red: 1.00, green: 1.00, blue: 1.00, alpha:1)
-    static let colorBrandFirstMedium = UIColor(red: 0.34, green: 0.34, blue: 0.34, alpha:1)
-    static let colorBrandSecondDark = UIColor(red: 1.00, green: 0.92, blue: 0.32, alpha:1)
-    static let colorBrandSecondExtraDark = UIColor(red: 0.38, green: 0.34, blue: 0.00, alpha:1)
-    static let colorBrandSecondLight = UIColor(red: 1.00, green: 0.99, blue: 0.90, alpha:1)
-    static let colorBrandSecondMedium = UIColor(red: 1.00, green: 0.95, blue: 0.60, alpha:1)
-    static let colorInterfaceActionDark = UIColor(red: 0.00, green: 0.62, blue: 0.93, alpha:1)
-    static let colorInterfaceActionExtraDark = UIColor(red: 0.10, green: 0.36, blue: 0.66, alpha:1)
-    static let colorInterfaceActionLight = UIColor(red: 0.90, green: 0.97, blue: 1.00, alpha:1)
-    static let colorInterfaceActionMedium = UIColor(red: 0.48, green: 0.84, blue: 1.00, alpha:1)
-    static let colorInterfaceAlertDark = UIColor(red: 0.96, green: 0.73, blue: 0.31, alpha:1)
-    static let colorInterfaceAlertExtraDark = UIColor(red: 0.84, green: 0.56, blue: 0.00, alpha:1)
-    static let colorInterfaceAlertLight = UIColor(red: 1.00, green: 0.99, blue: 0.90, alpha:1)
-    static let colorInterfaceAlertMedium = UIColor(red: 1.00, green: 0.94, blue: 0.52, alpha:1)
-    static let colorInterfaceContentDark = UIColor(red: 0.13, green: 0.13, blue: 0.13, alpha:1)
-    static let colorInterfaceContentExtraDark = UIColor(red: 0.00, green: 0.00, blue: 0.00, alpha:1)
-    static let colorInterfaceContentLight = UIColor(red: 1.00, green: 1.00, blue: 1.00, alpha:1)
-    static let colorInterfaceContentMedium = UIColor(red: 0.34, green: 0.34, blue: 0.34, alpha:1)
-    static let colorInterfaceHighlightDark = UIColor(red: 0.60, green: 0.39, blue: 0.93, alpha:1)
-    static let colorInterfaceHighlightExtraDark = UIColor(red: 0.33, green: 0.10, blue: 0.66, alpha:1)
-    static let colorInterfaceHighlightLight = UIColor(red: 0.95, green: 0.92, blue: 1.00, alpha:1)
-    static let colorInterfaceHighlightMedium = UIColor(red: 0.78, green: 0.64, blue: 1.00, alpha:1)
-    static let colorInterfaceNegativeDark = UIColor(red: 0.95, green: 0.40, blue: 0.40, alpha:1)
-    static let colorInterfaceNegativeExtraDark = UIColor(red: 0.71, green: 0.01, blue: 0.00, alpha:1)
-    static let colorInterfaceNegativeLight = UIColor(red: 0.99, green: 0.93, blue: 0.93, alpha:1)
-    static let colorInterfaceNegativeMedium = UIColor(red: 0.96, green: 0.60, blue: 0.60, alpha:1)
-    static let colorInterfacePositiveDark = UIColor(red: 0.15, green: 0.63, blue: 0.35, alpha:1)
-    static let colorInterfacePositiveExtraDark = UIColor(red: 0.00, green: 0.40, blue: 0.07, alpha:1)
-    static let colorInterfacePositiveLight = UIColor(red: 0.92, green: 0.98, blue: 0.95, alpha:1)
-    static let colorInterfacePositiveMedium = UIColor(red: 0.63, green: 0.91, blue: 0.75, alpha:1)
-    static let colorInterfaceShadeDark = UIColor(red: 0.86, green: 0.86, blue: 0.86, alpha:1)
-    static let colorInterfaceShadeExtraDark = UIColor(red: 0.70, green: 0.70, blue: 0.70, alpha:1)
-    static let colorInterfaceShadeLight = UIColor(red: 0.97, green: 0.97, blue: 0.97, alpha:1)
-    static let colorInterfaceShadeMedium = UIColor(red: 0.95, green: 0.95, blue: 0.95, alpha:1)
+    static let colorBrandFirstDark = UIColor(red: 0.13, green: 0.13, blue: 0.13, alpha: 1)
+    static let colorBrandFirstExtraDark = UIColor(red: 0.00, green: 0.00, blue: 0.00, alpha: 1)
+    static let colorBrandFirstLight = UIColor(red: 1.00, green: 1.00, blue: 1.00, alpha: 1)
+    static let colorBrandFirstMedium = UIColor(red: 0.34, green: 0.34, blue: 0.34, alpha: 1)
+    static let colorBrandSecondDark = UIColor(red: 1.00, green: 0.92, blue: 0.32, alpha: 1)
+    static let colorBrandSecondExtraDark = UIColor(red: 0.38, green: 0.34, blue: 0.00, alpha: 1)
+    static let colorBrandSecondLight = UIColor(red: 1.00, green: 0.99, blue: 0.90, alpha: 1)
+    static let colorBrandSecondMedium = UIColor(red: 1.00, green: 0.95, blue: 0.60, alpha: 1)
+    static let colorInterfaceActionDark = UIColor(red: 0.00, green: 0.62, blue: 0.93, alpha: 1)
+    static let colorInterfaceActionExtraDark = UIColor(red: 0.10, green: 0.36, blue: 0.66, alpha: 1)
+    static let colorInterfaceActionLight = UIColor(red: 0.90, green: 0.97, blue: 1.00, alpha: 1)
+    static let colorInterfaceActionMedium = UIColor(red: 0.48, green: 0.84, blue: 1.00, alpha: 1)
+    static let colorInterfaceAlertDark = UIColor(red: 0.96, green: 0.73, blue: 0.31, alpha: 1)
+    static let colorInterfaceAlertExtraDark = UIColor(red: 0.84, green: 0.56, blue: 0.00, alpha: 1)
+    static let colorInterfaceAlertLight = UIColor(red: 1.00, green: 0.99, blue: 0.90, alpha: 1)
+    static let colorInterfaceAlertMedium = UIColor(red: 1.00, green: 0.94, blue: 0.52, alpha: 1)
+    static let colorInterfaceContentDark = UIColor(red: 0.13, green: 0.13, blue: 0.13, alpha: 1)
+    static let colorInterfaceContentExtraDark = UIColor(red: 0.00, green: 0.00, blue: 0.00, alpha: 1)
+    static let colorInterfaceContentLight = UIColor(red: 1.00, green: 1.00, blue: 1.00, alpha: 1)
+    static let colorInterfaceContentMedium = UIColor(red: 0.34, green: 0.34, blue: 0.34, alpha: 1)
+    static let colorInterfaceHighlightDark = UIColor(red: 0.60, green: 0.39, blue: 0.93, alpha: 1)
+    static let colorInterfaceHighlightExtraDark = UIColor(red: 0.33, green: 0.10, blue: 0.66, alpha: 1)
+    static let colorInterfaceHighlightLight = UIColor(red: 0.95, green: 0.92, blue: 1.00, alpha: 1)
+    static let colorInterfaceHighlightMedium = UIColor(red: 0.78, green: 0.64, blue: 1.00, alpha: 1)
+    static let colorInterfaceNegativeDark = UIColor(red: 0.95, green: 0.40, blue: 0.40, alpha: 1)
+    static let colorInterfaceNegativeExtraDark = UIColor(red: 0.71, green: 0.01, blue: 0.00, alpha: 1)
+    static let colorInterfaceNegativeLight = UIColor(red: 0.99, green: 0.93, blue: 0.93, alpha: 1)
+    static let colorInterfaceNegativeMedium = UIColor(red: 0.96, green: 0.60, blue: 0.60, alpha: 1)
+    static let colorInterfacePositiveDark = UIColor(red: 0.15, green: 0.63, blue: 0.35, alpha: 1)
+    static let colorInterfacePositiveExtraDark = UIColor(red: 0.00, green: 0.40, blue: 0.07, alpha: 1)
+    static let colorInterfacePositiveLight = UIColor(red: 0.92, green: 0.98, blue: 0.95, alpha: 1)
+    static let colorInterfacePositiveMedium = UIColor(red: 0.63, green: 0.91, blue: 0.75, alpha: 1)
+    static let colorInterfaceShadeDark = UIColor(red: 0.86, green: 0.86, blue: 0.86, alpha: 1)
+    static let colorInterfaceShadeExtraDark = UIColor(red: 0.70, green: 0.70, blue: 0.70, alpha: 1)
+    static let colorInterfaceShadeLight = UIColor(red: 0.97, green: 0.97, blue: 0.97, alpha: 1)
+    static let colorInterfaceShadeMedium = UIColor(red: 0.95, green: 0.95, blue: 0.95, alpha: 1)
     static let fontFamilyDefault = "SourceSansPro-Regular"
     static let fontStyleQuote = "SourceSansPro-Italic"
     static let fontStyleWeightBold = 600
@@ -53,15 +53,15 @@ public class NitenTokens {
     static let fontStyleWeightRegular = 400
     static let opacityOpaque = 0.6
     static let opacityTranslucent = 0.35
-    static let shadowOffsetBottom1 = CGSize(width: 0, height:2)
-    static let shadowOffsetBottom2 = CGSize(width: 0, height:4)
-    static let shadowOffsetBottom3 = CGSize(width: 0, height:12)
-    static let shadowOffsetTop1 = CGSize(width: 0, height:-2)
-    static let shadowOffsetTop2 = CGSize(width: 0, height:-4)
-    static let shadowOffsetTop3 = CGSize(width: 0, height:-12)
-    static let shadowRadius1 = 4
-    static let shadowRadius2 = 12
-    static let shadowRadius3 = 24
+    static let shadowOffsetBottom1 = CGSize(width: 0, height: 2)
+    static let shadowOffsetBottom2 = CGSize(width: 0, height: 4)
+    static let shadowOffsetBottom3 = CGSize(width: 0, height: 12)
+    static let shadowOffsetTop1 = CGSize(width: 0, height: -2)
+    static let shadowOffsetTop2 = CGSize(width: 0, height: -4)
+    static let shadowOffsetTop3 = CGSize(width: 0, height: -12)
+    static let shadowRadius1 = CGFloat(4.00)
+    static let shadowRadius2 = CGFloat(12.00)
+    static let shadowRadius3 = CGFloat(24.00)
     static let sizeBorderRadiusL = CGFloat(16.00)
     static let sizeBorderRadiusM = CGFloat(8.00)
     static let sizeBorderRadiusNone = CGFloat(0.00)

--- a/package-lock.json
+++ b/package-lock.json
@@ -234,8 +234,7 @@
     "tinycolor2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
-      "dev": true
+      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "style-dictionary": "^2.8.1"
   },
   "dependencies": {
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "tinycolor2": "^1.4.1"
   }
 }


### PR DESCRIPTION
**DESCRIPTION**

The generated file with tokens for iOS plataform didn't had some necessary whitespaces and the `shadowRadius` tokens were generated in a wrong format. This PR updates the build file and correct these problems. 

**CHANGELOG**

* Fix the `size/CGSize` transform;
* Install the `TinyColor` library used in the `color/UIColorSwift` transform;
* Create the `isColor` matcher used in the `color/UIColorSwift` transform;
* Overwrite and fix the `color/UIColorSwift` transform;
* Create the `isShadowRadius ` matcher used in the `size/shadowRadiusToCGFloat` transform;
* Create the `size/shadowRadiusToCGFloat` transform;
* Generate new file with tokens for iOS platform.