### PR TITLE
Niten import

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+const { exec } = require('child_process');
+const path = require('path');
+const dist = process.argv[3];
+const nitenPath = path.resolve(__dirname, '../')
+const command = `cp ${nitenPath}/build/web/_niten-tokens.scss ${dist}`;
+
+exec(command, (err, stdout, stderr) => {
+  if(err) {
+    return console.log(err);
+  }
+
+  console.log('Finish import Niten Tokens with success! :)');
+})

--- a/build/android/niten_colors.xml
+++ b/build/android/niten_colors.xml
@@ -2,7 +2,7 @@
 
 <!--
   Do not edit directly
-  Generated on Tue, 06 Aug 2019 18:40:46 GMT
+  Generated on Fri, 16 Aug 2019 19:57:44 GMT
 -->
 <resources>
   <color name="color_brand_first_extra_dark">#000000</color>

--- a/build/android/niten_dimens.xml
+++ b/build/android/niten_dimens.xml
@@ -2,7 +2,7 @@
 
 <!--
   Do not edit directly
-  Generated on Tue, 06 Aug 2019 18:40:46 GMT
+  Generated on Fri, 16 Aug 2019 19:57:44 GMT
 -->
 <resources>
   <dimen name="size_border_radius_none">0dp</dimen>

--- a/build/android/niten_font_dimens.xml
+++ b/build/android/niten_font_dimens.xml
@@ -2,7 +2,7 @@
 
 <!--
   Do not edit directly
-  Generated on Tue, 06 Aug 2019 18:40:46 GMT
+  Generated on Fri, 16 Aug 2019 19:57:44 GMT
 -->
 <resources>
   <dimen name="size_font_xxl">60dp</dimen>

--- a/build/ios/NitenTokens.swift
+++ b/build/ios/NitenTokens.swift
@@ -3,7 +3,7 @@
 // NitenTokens.swift
 //
 // Do not edit directly
-// Generated on Tue, 06 Aug 2019 18:40:46 GMT
+// Generated on Fri, 16 Aug 2019 19:57:44 GMT
 //
 
 
@@ -51,8 +51,8 @@ public class NitenTokens {
     static let fontStyleWeightBold = 600
     static let fontStyleWeightLight = 300
     static let fontStyleWeightRegular = 400
-    static let opacityOpaque = 0.6
-    static let opacityTranslucent = 0.35
+    static let opacityOpaque = .6
+    static let opacityTranslucent = .35
     static let shadowOffsetBottom1 = CGSize(width: 0, height: 2)
     static let shadowOffsetBottom2 = CGSize(width: 0, height: 4)
     static let shadowOffsetBottom3 = CGSize(width: 0, height: 12)

--- a/build/web/_niten-tokens.scss
+++ b/build/web/_niten-tokens.scss
@@ -1,46 +1,46 @@
 /**
  * Do not edit directly
- * Generated on Tue, 06 Aug 2019 18:40:46 GMT
+ * Generated on Fri, 16 Aug 2019 19:57:44 GMT
  */
 
 $color-brand-first-extra-dark: #000000;
 $color-brand-first-dark: #212121;
 $color-brand-first-medium: #575757;
-$color-brand-first-light: #FFFFFF;
+$color-brand-first-light: #ffffff;
 $color-brand-second-extra-dark: #615600;
-$color-brand-second-dark: #FFEA52;
-$color-brand-second-medium: #FFF399;
-$color-brand-second-light: #FFFCE6;
+$color-brand-second-dark: #ffea52;
+$color-brand-second-medium: #fff399;
+$color-brand-second-light: #fffce6;
 $color-interface-positive-extra-dark: #006513;
-$color-interface-positive-dark: #25A159;
-$color-interface-positive-medium: #A0E9BE;
-$color-interface-positive-light: #EAFAF1;
-$color-interface-alert-extra-dark: #D78E00;
-$color-interface-alert-dark: #F6BA50;
-$color-interface-alert-medium: #FFF085;
-$color-interface-alert-light: #FFFCE6;
-$color-interface-negative-extra-dark: #B40300;
-$color-interface-negative-dark: #F26565;
-$color-interface-negative-medium: #F49999;
-$color-interface-negative-light: #FDECEC;
-$color-interface-highlight-extra-dark: #5319A9;
-$color-interface-highlight-dark: #9A63EE;
-$color-interface-highlight-medium: #C8A3FF;
-$color-interface-highlight-light: #F3EBFF;
-$color-interface-action-extra-dark: #195CA9;
-$color-interface-action-dark: #009DED;
-$color-interface-action-medium: #7AD6FF;
-$color-interface-action-light: #E5F7FF;
+$color-interface-positive-dark: #25a159;
+$color-interface-positive-medium: #a0e9be;
+$color-interface-positive-light: #eafaf1;
+$color-interface-alert-extra-dark: #d78e00;
+$color-interface-alert-dark: #f6ba50;
+$color-interface-alert-medium: #fff085;
+$color-interface-alert-light: #fffce6;
+$color-interface-negative-extra-dark: #b40300;
+$color-interface-negative-dark: #f26565;
+$color-interface-negative-medium: #f49999;
+$color-interface-negative-light: #fdecec;
+$color-interface-highlight-extra-dark: #5319a9;
+$color-interface-highlight-dark: #9a63ee;
+$color-interface-highlight-medium: #c8a3ff;
+$color-interface-highlight-light: #f3ebff;
+$color-interface-action-extra-dark: #195ca9;
+$color-interface-action-dark: #009ded;
+$color-interface-action-medium: #7ad6ff;
+$color-interface-action-light: #e5f7ff;
 $color-interface-content-extra-dark: #000000;
 $color-interface-content-dark: #212121;
 $color-interface-content-medium: #575757;
-$color-interface-content-light: #FFFFFF;
-$color-interface-shade-extra-dark: #B2B2B2;
-$color-interface-shade-dark: #DBDBDB;
-$color-interface-shade-medium: #F2F2F2;
-$color-interface-shade-light: #F8F8F8;
-$opacity-translucent: 0.35;
-$opacity-opaque: 0.6;
+$color-interface-content-light: #ffffff;
+$color-interface-shade-extra-dark: #b2b2b2;
+$color-interface-shade-dark: #dbdbdb;
+$color-interface-shade-medium: #f2f2f2;
+$color-interface-shade-light: #f8f8f8;
+$opacity-translucent: .35;
+$opacity-opaque: .6;
 $font-style-weight-light: 300;
 $font-style-weight-regular: 400;
 $font-style-weight-bold: 600;

--- a/package.json
+++ b/package.json
@@ -25,8 +25,12 @@
   "devDependencies": {
     "style-dictionary": "^2.8.1"
   },
+  "bin": {
+    "niten": "./bin/index.js"
+  },
   "dependencies": {
     "lodash": "^4.17.15",
     "tinycolor2": "^1.4.1"
-  }
+  },
+  "preferGlobal": true
 }

--- a/src/properties/globals/color/base.json
+++ b/src/properties/globals/color/base.json
@@ -12,7 +12,7 @@
           "value": "#575757"
         },
         "light": {
-          "value": "#FFFFFF"
+          "value": "#ffffff"
         }
       },
       "second": {
@@ -20,13 +20,13 @@
           "value": "#615600"
         },
         "dark": {
-          "value": "#FFEA52"
+          "value": "#ffea52"
         },
         "medium": {
-          "value": "#FFF399"
+          "value": "#fff399"
         },
         "light": {
-          "value": "#FFFCE6"
+          "value": "#fffce6"
         }
       }
     },
@@ -36,69 +36,69 @@
           "value": "#006513"
         },
         "dark": {
-          "value": "#25A159"
+          "value": "#25a159"
         },
         "medium": {
-          "value": "#A0E9BE"
+          "value": "#a0e9be"
         },
         "light": {
-          "value": "#EAFAF1"
+          "value": "#eafaf1"
         }
       },
       "alert": {
         "extra-dark": {
-          "value": "#D78E00"
+          "value": "#d78e00"
         },
         "dark": {
-          "value": "#F6BA50"
+          "value": "#f6ba50"
         },
         "medium": {
-          "value": "#FFF085"
+          "value": "#fff085"
         },
         "light": {
-          "value": "#FFFCE6"
+          "value": "#fffce6"
         }
       },
       "negative": {
         "extra-dark": {
-          "value": "#B40300"
+          "value": "#b40300"
         },
         "dark": {
-          "value": "#F26565"
+          "value": "#f26565"
         },
         "medium": {
-          "value": "#F49999"
+          "value": "#f49999"
         },
         "light": {
-          "value": "#FDECEC"
+          "value": "#fdecec"
         }
       },
       "highlight": {
         "extra-dark": {
-          "value": "#5319A9"
+          "value": "#5319a9"
         },
         "dark": {
-          "value": "#9A63EE"
+          "value": "#9a63ee"
         },
         "medium": {
-          "value": "#C8A3FF"
+          "value": "#c8a3ff"
         },
         "light": {
-          "value": "#F3EBFF"
+          "value": "#f3ebff"
         }
       },
       "action": {
         "extra-dark": {
-          "value": "#195CA9"
+          "value": "#195ca9"
         },
         "dark": {
-          "value": "#009DED"
+          "value": "#009ded"
         },
         "medium": {
-          "value": "#7AD6FF"
+          "value": "#7ad6ff"
         },
         "light": {
-          "value": "#E5F7FF"
+          "value": "#e5f7ff"
         }
       },
       "content": {
@@ -112,21 +112,21 @@
           "value": "#575757"
         },
         "light": {
-          "value": "#FFFFFF"
+          "value": "#ffffff"
         }
       },
       "shade": {
         "extra-dark": {
-          "value": "#B2B2B2"
+          "value": "#b2b2b2"
         },
         "dark": {
-          "value": "#DBDBDB"
+          "value": "#dbdbdb"
         },
         "medium": {
-          "value": "#F2F2F2"
+          "value": "#f2f2f2"
         },
         "light": {
-          "value": "#F8F8F8"
+          "value": "#f8f8f8"
         }
       }
     }

--- a/src/properties/globals/color/opacity.json
+++ b/src/properties/globals/color/opacity.json
@@ -1,10 +1,10 @@
 {
   "opacity": {
     "translucent": {
-      "value": "0.35"
+      "value": ".35"
     },
     "opaque": {
-      "value": "0.6"
+      "value": ".6"
     }
   }
 }


### PR DESCRIPTION
**DESCRIPTION**

We were having the following problem: in Gaiden, Niten import was done like `@import 'node_modules/@getninjas/niten-tokens/build/web/niten-tokens';` in `gaiden.scss` file and the files where the variables are used. This is bad because we needed an `import` in each file and also because in tanya, when we imported the `_colors.scss` css for example, the path `../../../node_modules/@getninjas/niten...` doesn't exist anymore, since Gaiden is also a module it doesn't have `node_modules`. So I created a script that can be run on the terminal to import Niten css into any project. Niten must be installed globally and to import into Tanya, for example, the command would be `niten --path" src/static/scss/gaiden"`

**CHANGELOG**

* Niten is now a global package
